### PR TITLE
add: `ResizableImage`

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,1 +1,1 @@
-nicklockwood/SwiftFormat@0.49.7
+nicklockwood/SwiftFormat@0.49.8

--- a/Sources/SwiftUICommon/Extension/CGSize+.swift
+++ b/Sources/SwiftUICommon/Extension/CGSize+.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//
+//
+//  Created by Yusuke Hosonuma on 2022/05/12.
+//
+
+import SwiftUI
+
+public extension CGSize {
+    func contains(_ other: CGSize) -> Bool {
+        width < other.width && height < other.height
+    }
+}

--- a/Sources/SwiftUICommon/Extension/View+.swift
+++ b/Sources/SwiftUICommon/Extension/View+.swift
@@ -20,9 +20,7 @@ public extension View {
     }
     #endif
 
-    //
-    // MARK: For readability.
-    //
+    // MARK: - Readability
 
     func enabled(_ enabled: Bool) -> some View {
         disabled(enabled == false)
@@ -32,9 +30,7 @@ public extension View {
         frame(width: size?.width, height: size?.height)
     }
 
-    //
-    // MARK: Add Modifier according to condition.
-    //
+    // MARK: - Condition
 
     func extend<Content: View>(@ViewBuilder transform: (Self) -> Content) -> some View {
         transform(self)
@@ -58,9 +54,7 @@ public extension View {
         }
     }
 
-    //
-    // MARK: Decoration
-    //
+    // MARK: - Decoration
 
     func border(_ color: Color, width: CGFloat = 1, edge: Edge.Set) -> some View {
         overlay(
@@ -87,10 +81,8 @@ public extension View {
         )
     }
 
-    //
-    // MARK: Preference
-    //
-    
+    // MARK: - Preference
+
     @ViewBuilder
     func sizePreference() -> some View {
         background(
@@ -100,7 +92,7 @@ public extension View {
             }
         )
     }
-    
+
     @ViewBuilder
     func onChangeSizePreference(_ perform: @escaping (CGSize) -> Void) -> some View {
         onPreferenceChange(SizeKey.self) { size in
@@ -110,9 +102,7 @@ public extension View {
         }
     }
 
-    //
-    // MARK: For debug.
-    //
+    // MARK: - Debug
 
     func debug(_ handler: () -> Void) -> Self {
         handler()
@@ -126,7 +116,7 @@ extension View {
     func boundsPreference() -> some View {
         anchorPreference(key: BoundsKey.self, value: .bounds) { $0 }
     }
-    
+
     @ViewBuilder
     func onChangePreferenceBounds(_ geometry: GeometryProxy, _ handler: @escaping (CGSize) -> Void) -> some View {
         onPreferenceChange(BoundsKey.self) { anchor in
@@ -137,7 +127,7 @@ extension View {
     }
 }
 
-// MARK: PreferenceKey
+// MARK: - PreferenceKey
 
 private struct BoundsKey: PreferenceKey {
     static var defaultValue: Anchor<CGRect>?

--- a/Sources/SwiftUICommon/Extension/View+.swift
+++ b/Sources/SwiftUICommon/Extension/View+.swift
@@ -118,10 +118,10 @@ extension View {
     }
 
     @ViewBuilder
-    func onChangePreferenceBounds(_ geometry: GeometryProxy, _ handler: @escaping (CGSize) -> Void) -> some View {
+    func onChangeBoundsPreference(_ geometry: GeometryProxy, perform: @escaping (CGSize) -> Void) -> some View {
         onPreferenceChange(BoundsKey.self) { anchor in
             if let anchor = anchor {
-                handler(geometry[anchor].size)
+                perform(geometry[anchor].size)
             }
         }
     }

--- a/Sources/SwiftUICommon/Extension/View+.swift
+++ b/Sources/SwiftUICommon/Extension/View+.swift
@@ -21,19 +21,19 @@ public extension View {
     #endif
 
     //
-
     // MARK: For readability.
-
     //
 
     func enabled(_ enabled: Bool) -> some View {
         disabled(enabled == false)
     }
 
+    func frame(size: CGSize?) -> some View {
+        frame(width: size?.width, height: size?.height)
+    }
+
     //
-
     // MARK: Add Modifier according to condition.
-
     //
 
     func extend<Content: View>(@ViewBuilder transform: (Self) -> Content) -> some View {
@@ -59,9 +59,7 @@ public extension View {
     }
 
     //
-
     // MARK: Decoration
-
     //
 
     func border(_ color: Color, width: CGFloat = 1, edge: Edge.Set) -> some View {
@@ -90,13 +88,69 @@ public extension View {
     }
 
     //
+    // MARK: Preference
+    //
+    
+    @ViewBuilder
+    func sizePreference() -> some View {
+        background(
+            GeometryReader { local in
+                Color.clear
+                    .preference(key: SizeKey.self, value: local.size)
+            }
+        )
+    }
+    
+    @ViewBuilder
+    func onChangeSizePreference(_ perform: @escaping (CGSize) -> Void) -> some View {
+        onPreferenceChange(SizeKey.self) { size in
+            if let size = size {
+                perform(size)
+            }
+        }
+    }
 
+    //
     // MARK: For debug.
-
     //
 
     func debug(_ handler: () -> Void) -> Self {
         handler()
         return self
+    }
+}
+
+@available(iOS 15, *)
+extension View {
+    @ViewBuilder
+    func boundsPreference() -> some View {
+        anchorPreference(key: BoundsKey.self, value: .bounds) { $0 }
+    }
+    
+    @ViewBuilder
+    func onChangePreferenceBounds(_ geometry: GeometryProxy, _ handler: @escaping (CGSize) -> Void) -> some View {
+        onPreferenceChange(BoundsKey.self) { anchor in
+            if let anchor = anchor {
+                handler(geometry[anchor].size)
+            }
+        }
+    }
+}
+
+// MARK: PreferenceKey
+
+private struct BoundsKey: PreferenceKey {
+    static var defaultValue: Anchor<CGRect>?
+
+    static func reduce(value: inout Anchor<CGRect>?, nextValue: () -> Anchor<CGRect>?) {
+        value = nextValue()
+    }
+}
+
+private struct SizeKey: PreferenceKey {
+    static var defaultValue: CGSize?
+
+    static func reduce(value: inout CGSize?, nextValue: () -> CGSize?) {
+        value = nextValue()
     }
 }

--- a/Sources/SwiftUICommon/View/ResizableImage.swift
+++ b/Sources/SwiftUICommon/View/ResizableImage.swift
@@ -1,0 +1,47 @@
+//
+//  File.swift
+//
+//
+//  Created by Yusuke Hosonuma on 2022/05/12.
+//
+
+import SwiftUI
+
+public extension Image {
+    func original(or contentMode: ContentMode) -> some View {
+        ResizableImage(image: self, contentMode: contentMode)
+    }
+}
+
+private struct ResizableImage: View {
+    let image: Image
+    let contentMode: ContentMode
+
+    @State private var size: CGSize?
+
+    var body: some View {
+        GeometryReader { geometry in
+            Group {
+                if let size = size {
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: contentMode)
+                        .frame(size: size)
+                } else {
+                    image.sizePreference() // 💡 get original image size. (1st time only)
+                }
+            }
+            .onChangeSizePreference { imageSize in
+                if imageSize.width < geometry.size.width {
+                    size = imageSize
+                } else {
+                    size = .init(
+                        width: geometry.size.width,
+                        height: imageSize.height * (geometry.size.width / imageSize.width)
+                    )
+                }
+            }
+        }
+        .frame(size: size)
+    }
+}


### PR DESCRIPTION
## ResizableImage

Resize only if the area overflows. (show as original-size if it included in area)

- View
  - `original(or contentMode: ContentMode) -> some View`

## Extension

- CGSize
  - `contains(_ other: CGSize) -> Bool`
- View
  - `frame(size: CGSize?) -> some View`
  - `sizePreference() -> some View`
  - `onChangeSizePreference(_ perform: @escaping (CGSize) -> Void) -> some View`
- View (iOS 15+)
  - `boundsPreference() -> some View`
  - `onChangeBoundsPreference(_ geometry: GeometryProxy, perform: @escaping (CGSize) -> Void) -> some View`